### PR TITLE
Use https instead of http for fddb.info

### DIFF
--- a/lib/nom/nom.rb
+++ b/lib/nom/nom.rb
@@ -106,7 +106,7 @@ module Nom
             term = args.join(" ")
             puts
             term = term.encode("ISO-8859-1")
-            url = "http://fddb.info/db/de/suche/?udd=0&cat=site-de&search=#{URI.escape(term)}"
+            url = "https://fddb.info/db/de/suche/?udd=0&cat=site-de&search=#{URI.escape(term)}"
 
             page = Nokogiri::HTML(open(url))
             results = page.css(".standardcontent a").map{|a| a["href"]}.select{|href| href.include? "lebensmittel"}


### PR DESCRIPTION
Search fails for me when using `http://fddb.info/db/de/suche/?udd=0&cat=site-de&search=#{URI.escape(term)}`—I’m getting an invalid redirect error. Using `https` as a scheme fixes this.

Cheers

## Appendix A: Original Traceback

```
$ nom search food
(no matching entries found)
---------------------
     (0) total

/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/open-uri.rb:225:in `open_loop'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/open-uri.rb:151:in `open_uri'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/open-uri.rb:717:in `open'
/System/Library/Frameworks/Ruby.framework/Versions/2.3/usr/lib/ruby/2.3.0/open-uri.rb:35:in `open'
/Library/Ruby/Gems/2.3.0/gems/nom-0.1.3/lib/nom/nom.rb:111:in `search'
/Library/Ruby/Gems/2.3.0/gems/nom-0.1.3/bin/nom:61:in `<top (required)>'
/usr/local/bin/nom:22:in `load'
/usr/local/bin/nom:22:in `<main>'
redirection forbidden: http://fddb.info/db/de/suche/?udd=0&cat=site-de&search=food -> https://fddb.info/db/de/suche/?udd=0&cat=site-de&search=food
Something went wrong. Usage of this command is: nom search <term>
```