### PR TITLE
fix URI.escape and URI.open deprecation warnings

### DIFF
--- a/lib/nom/nom.rb
+++ b/lib/nom/nom.rb
@@ -106,13 +106,13 @@ module Nom
             term = args.join(" ")
             puts
             term = term.encode("ISO-8859-1")
-            url = "https://fddb.info/db/de/suche/?udd=0&cat=site-de&search=#{URI.escape(term)}"
+            url = "https://fddb.info/db/de/suche/?udd=0&cat=site-de&search=#{CGI.escape(term)}"
 
-            page = Nokogiri::HTML(open(url))
+            page = Nokogiri::HTML(URI.open(url))
             results = page.css(".standardcontent a").map{|a| a["href"]}.select{|href| href.include? "lebensmittel"}
 
             results[0..4].each do |result|
-                page = Nokogiri::HTML(open(result))
+                page = Nokogiri::HTML(URI.open(result))
                 title = page.css(".breadcrumb a").last.text
                 brand = page.css(".standardcontent p a").select{|a| a["href"].include? "hersteller"}.first.text
                 puts "#{title} (#{brand})"


### PR DESCRIPTION
Fixes #6

    $ ./bin/nom search foo
    Previous log entries:
    (no matching entries found)
    ---------------------
         (0) total
    .../lib/nom/nom.rb:109: warning: URI.escape is obsolete
    .../lib/nom/nom.rb:111: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
    .../lib/nom/nom.rb:115: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
    Food Diet Pro, Schoko (Powerstar Food)
        (707) 1 Glas (200 ml)
        (106) 1 Becher (30 ml)

As the stdlib [1] and the warnings suggest, use CGI.escape and URI.open
instead.

[1]: https://ruby-doc.org/stdlib-2.7.1/libdoc/uri/rdoc/URI/Escape.html#method-i-escape-label-Description