### PR TITLE
cap rates to a minimum of 0.1

### DIFF
--- a/lib/nom/config.rb
+++ b/lib/nom/config.rb
@@ -45,6 +45,11 @@ module Nom
                 raise "Unknown configuration option '#{key}'"
             end
 
+            if key == "rate" and @config["rate"] < 0.1
+               puts "Warning: rates smaller than 0.1 are not supported, capping to 0.1"
+               0.1
+            end
+
             if @defaults[key][2] == Float
                 v.to_f
             elsif @defaults[key][2] == Date


### PR DESCRIPTION
With lower rates than 0.1, the algorithm to calculate the allowed kcal values can takes a very long time to run, and the plot also explodes in the y axis. Print a warning in that case, and cap the value to a minimum of 0.1.