### PR TITLE
support --help

### DIFF
--- a/bin/nom
+++ b/bin/nom
@@ -16,7 +16,7 @@ commands = [
     [ "edit", "e", nil, "Edit the input file" ],
     [ "editw", "ew", nil, "Edit the weight file" ],
     [ "config", "c", nil, "Edit the config file (see below for options)" ],
-    [ "help", nil, nil, "Print this help" ],
+    [ "help", "--help", nil, "Print this help" ],
 ]
 
 nom = Nom::Nom.new
@@ -42,7 +42,7 @@ if command.nil?
     command = commands.find{|c| c[0] == cmd_name or c[1] == cmd_name}
 end
 
-if command[0] == "help"
+if command[0] == "help" or command[0] == "--help"
     puts "Available subcommands:"
     commands.each do |c|
         puts "  "+"#{c[1].to_s.rjust(2)}#{c[1] ? "," : " "} #{c[0]} #{c[2]}".ljust(32)+c[3]


### PR DESCRIPTION
Most UNIX tools support this, so follow the principle of least surprise.
Yes, --help is not actually a "short" parameter, but it works without changing too much of the code… 🙂