### PR TITLE
fix evaluation order when detecting cmd_name

### DIFF
--- a/bin/nom
+++ b/bin/nom
@@ -26,7 +26,7 @@ aliases = {
 
 nom = Nom::Nom.new
 
-cmd_name = ARGV.shift or "status"
+cmd_name = (ARGV.shift or "status")
 
 if aliases.include? cmd_name.to_sym
     cmd_name = aliases[cmd_name.to_sym]


### PR DESCRIPTION
Apparently the '=' operator binds stronger than the 'or' operator:
```
$ irb
irb(main):001:0> array = []
=> []
irb(main):002:0> cmd_name = array.shift or "status"
=> "status"
irb(main):003:0> cmd_name.inspect
=> "nil"
irb(main):004:0> cmd_name = (array.shift or "status")
=> "status"
irb(main):005:0> cmd_name.inspect
=> "\"status\""
```

Put a pair of braces around it to fix the order.