### PR TITLE
Fix breaking problem on Ruby upgrade

### DIFF
--- a/lib/nom/config.rb
+++ b/lib/nom/config.rb
@@ -7,7 +7,7 @@ module Nom
 
             @config = {}
             if File.exists? file
-                @config = YAML.load_file(file)
+                @config = YAML.load_file(file, permitted_classes: [Date])
             end
 
             @defaults = {


### PR DESCRIPTION
I updated my Ruby install today, and nom didn't run afterwards:

```
/usr/lib/ruby/3.0.0/psych/class_loader.rb:99:in `find': Tried to load unspecified class: Date (Psych::DisallowedClass)
	from /usr/lib/ruby/3.0.0/psych/class_loader.rb:28:in `load'
	from (eval):2:in `date'
	from /usr/lib/ruby/3.0.0/psych/scalar_scanner.rb:66:in `tokenize'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:65:in `deserialize'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:130:in `visit_Psych_Nodes_Scalar'
	from /usr/lib/ruby/3.0.0/psych/visitors/visitor.rb:30:in `visit'
	from /usr/lib/ruby/3.0.0/psych/visitors/visitor.rb:6:in `accept'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:347:in `block in revive_hash'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:345:in `each'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:345:in `each_slice'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:345:in `revive_hash'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:169:in `visit_Psych_Nodes_Mapping'
	from /usr/lib/ruby/3.0.0/psych/visitors/visitor.rb:30:in `visit'
	from /usr/lib/ruby/3.0.0/psych/visitors/visitor.rb:6:in `accept'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:320:in `visit_Psych_Nodes_Document'
	from /usr/lib/ruby/3.0.0/psych/visitors/visitor.rb:30:in `visit'
	from /usr/lib/ruby/3.0.0/psych/visitors/visitor.rb:6:in `accept'
	from /usr/lib/ruby/3.0.0/psych/visitors/to_ruby.rb:35:in `accept'
	from /usr/lib/ruby/3.0.0/psych.rb:334:in `safe_load'
	from /usr/lib/ruby/3.0.0/psych.rb:369:in `load'
	from /usr/lib/ruby/3.0.0/psych.rb:671:in `block in load_file'
	from /usr/lib/ruby/3.0.0/psych.rb:670:in `open'
	from /usr/lib/ruby/3.0.0/psych.rb:670:in `load_file'
	from /home/rixx/.local/share/gem/ruby/3.0.0/gems/nom-0.1.4/lib/nom/config.rb:10:in `initialize'
	from /home/rixx/.local/share/gem/ruby/3.0.0/gems/nom-0.1.4/lib/nom/nom.rb:30:in `new'
	from /home/rixx/.local/share/gem/ruby/3.0.0/gems/nom-0.1.4/lib/nom/nom.rb:30:in `initialize'
	from /home/rixx/.local/share/gem/ruby/3.0.0/gems/nom-0.1.4/bin/nom:27:in `new'
	from /home/rixx/.local/share/gem/ruby/3.0.0/gems/nom-0.1.4/bin/nom:27:in `<top (required)>'
	from /home/rixx/.local/share/gem/ruby/3.0.0/bin/nom:25:in `load'
	from /home/rixx/.local/share/gem/ruby/3.0.0/bin/nom:25:in `<main>'
```

Apparently YAML loads require some classes to be whitelisted first. Fix tested by editing the installed file in-place, and everything works great again.